### PR TITLE
chore(devcontainer): add frontend-only setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,27 +1,21 @@
 {
-  "name": "react-vite-devcontainer",
-  "dockerComposeFile": [
-    "../docker-compose.yml"
-  ],
+  "name": "frontend (compose)",
+  "dockerComposeFile": ["../docker-compose.yml"],
   "service": "web",
   "workspaceFolder": "/app",
-  "overrideCommand": true,
-  "postCreateCommand": "npm install",
+  "overrideCommand": false,
   "forwardPorts": [5173],
-  "portsAttributes": {
-    "5173": {
-      "label": "Vite Dev Server",
-      "onAutoForward": "notify"
-    }
+  "portsAttributes": { "5173": { "label": "Vite dev server" } },
+  "containerEnv": {
+    "TZ": "Asia/Tokyo",
+    "CHOKIDAR_USEPOLLING": "true"
   },
-  "remoteUser": "node",
+  "postCreateCommand": "bash .devcontainer/setup.sh",
   "customizations": {
     "vscode": {
-      "extensions": [
-        "dbaeumer.vscode-eslint",
-        "esbenp.prettier-vscode"
-      ]
+      "settings": { "files.encoding": "utf8", "files.eol": "\n", "editor.tabSize": 2, "editor.formatOnSave": true },
+      "extensions": ["esbenp.prettier-vscode","dbaeumer.vscode-eslint"]
     }
-  }
+  },
+  "mounts": ["type=cache,target=/home/node/.npm"]
 }
-

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -e
+cd /app
+if [ -f package.json ]; then
+  corepack enable || true
+  if command -v pnpm >/dev/null 2>&1; then pm=pnpm
+  elif command -v yarn >/dev/null 2>&1; then pm=yarn
+  else pm=npm
+  fi
+  $pm install
+fi
+echo "✅ setup done"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,4 +4,8 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    host: true,
+    port: 5173,
+  },
 })


### PR DESCRIPTION
## Summary
- configure devcontainer for frontend-only workflow
- add setup script for dependency installation
- expose Vite dev server on host

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b05495e4f08329a030aec969fe9ced